### PR TITLE
Due to new Monad Proposal (AMP), won't compile

### DIFF
--- a/examples/ch10/Parse.hs
+++ b/examples/ch10/Parse.hs
@@ -78,7 +78,13 @@ parse parser initState
         Left err          -> Left err
         Right (result, _) -> Right result
 {-- /snippet parse --}
-{--
+
+{-- Applicative Monad Proposal (AMP) restrictions
+Due to the AMP [1], the code below no longer compiles.
+Tested GHCi version 7.10.3.
+
+[1]: https://wiki.haskell.org/Functor-Applicative-Monad_Proposal
+
 {-- snippet Monad --}
 instance Monad Parse where
     return = identity

--- a/examples/ch10/Parse.hs
+++ b/examples/ch10/Parse.hs
@@ -78,13 +78,14 @@ parse parser initState
         Left err          -> Left err
         Right (result, _) -> Right result
 {-- /snippet parse --}
-
+{--
 {-- snippet Monad --}
 instance Monad Parse where
     return = identity
     (>>=) = (==>)
     fail = bail
 {-- /snippet Monad --}
+--}
 
 {-- snippet getPut --}
 getState :: Parse ParseState


### PR DESCRIPTION
Commenting out will compile in GHCi.

https://wiki.haskell.org/Functor-Applicative-Monad_Proposal